### PR TITLE
Fix controlled input transform handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Build Storybook
         run: yarn build-storybook
 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Storybook tests
+        run: yarn workspace @lambdacurry/medusa-forms-docs test
+
       - name: Lint and format check
         run: yarn format-and-lint
 
@@ -47,4 +53,3 @@ jobs:
           name: test-failure
           path: apps/docs/storybook-static
           retention-days: 2
-

--- a/apps/docs/src/medusa-forms/ControlledCurrencyInput.stories.tsx
+++ b/apps/docs/src/medusa-forms/ControlledCurrencyInput.stories.tsx
@@ -1,6 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ControlledCurrencyInput } from '@lambdacurry/medusa-forms/controlled/ControlledCurrencyInput';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from '@storybook/test';
+import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -21,7 +23,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 interface CurrencyFormData {
-  price: string;
+  price: string | number;
 }
 
 // Base wrapper component for stories
@@ -59,6 +61,84 @@ const CurrencyInputWithHookForm = ({
       </div>
     </FormProvider>
   );
+};
+
+const CurrencyInputWithStringState = () => {
+  const form = useForm<CurrencyFormData>({
+    defaultValues: { price: '' },
+  });
+  const price = form.watch('price');
+
+  return (
+    <FormProvider {...form}>
+      <div className="w-[400px] space-y-4">
+        <ControlledCurrencyInput<CurrencyFormData> name="price" label="String price" symbol="$" code="usd" />
+        <pre className="rounded bg-gray-100 p-2 text-xs">
+          {JSON.stringify({ value: price, type: typeof price }, null, 2)}
+        </pre>
+      </div>
+    </FormProvider>
+  );
+};
+
+const CurrencyInputWithRequiredError = () => {
+  const form = useForm<CurrencyFormData>({
+    defaultValues: { price: '' },
+    mode: 'onChange',
+  });
+
+  useEffect(() => {
+    form.trigger('price').then(() => undefined);
+  }, [form]);
+
+  return (
+    <FormProvider {...form}>
+      <div className="w-[400px]">
+        <ControlledCurrencyInput
+          name="price"
+          label="Required price"
+          symbol="$"
+          code="usd"
+          rules={{ required: 'Price is required' }}
+        />
+      </div>
+    </FormProvider>
+  );
+};
+
+const CurrencyInputWithValueAsNumber = () => {
+  const form = useForm<CurrencyFormData>({
+    defaultValues: { price: '' },
+  });
+  const price = form.watch('price');
+
+  return (
+    <FormProvider {...form}>
+      <div className="w-[400px] space-y-4">
+        <ControlledCurrencyInput<CurrencyFormData>
+          name="price"
+          label="Numeric price"
+          symbol="$"
+          code="usd"
+          rules={{ valueAsNumber: true }}
+        />
+        <pre className="rounded bg-gray-100 p-2 text-xs">
+          {JSON.stringify({ value: price, type: typeof price }, null, 2)}
+        </pre>
+      </div>
+    </FormProvider>
+  );
+};
+
+const getStateOutput = (canvas: ReturnType<typeof within>) => canvas.getByText((content) => content.includes('"type"'));
+const getInputByName = (canvasElement: HTMLElement, name: string) => {
+  const input = canvasElement.querySelector<HTMLInputElement>(`input[name="${name}"]`);
+
+  if (!input) {
+    throw new Error(`Input with name "${name}" was not found.`);
+  }
+
+  return input;
 };
 
 // 1. Different Currency Symbols
@@ -192,6 +272,74 @@ export const RequiredFieldValidation: Story = {
       required
     />
   ),
+};
+
+export const RequiredRuleError: Story = {
+  args: {
+    name: 'price',
+    symbol: '$',
+    code: 'usd',
+  },
+  render: () => <CurrencyInputWithRequiredError />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      expect(canvas.getByText('Price is required')).toBeInTheDocument();
+    });
+  },
+};
+
+export const DefaultStringValue: Story = {
+  args: {
+    name: 'price',
+    symbol: '$',
+    code: 'usd',
+  },
+  render: () => <CurrencyInputWithStringState />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = getInputByName(canvasElement, 'price');
+    const state = getStateOutput(canvas);
+
+    await userEvent.type(input, '1234');
+
+    await waitFor(() => {
+      expect(input.value).toContain('1,234');
+      expect(state).toHaveTextContent('"value": "1234"');
+      expect(state).toHaveTextContent('"type": "string"');
+    });
+  },
+};
+
+export const ValueAsNumber: Story = {
+  args: {
+    name: 'price',
+    symbol: '$',
+    code: 'usd',
+  },
+  render: () => <CurrencyInputWithValueAsNumber />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = getInputByName(canvasElement, 'price');
+    const state = getStateOutput(canvas);
+
+    await userEvent.type(input, '1234');
+
+    await waitFor(() => {
+      expect(input.value).toContain('1,234');
+      expect(state).toHaveTextContent('"value": 1234');
+      expect(state).toHaveTextContent('"type": "number"');
+    });
+
+    await userEvent.clear(input);
+
+    await waitFor(() => {
+      expect(input.value).toBe('');
+      expect(state).toHaveTextContent('"value": null');
+      expect(state).toHaveTextContent('"type": "number"');
+    });
+  },
 };
 
 const customValidationSchema = z.object({

--- a/apps/docs/src/medusa-forms/ControlledInput.stories.tsx
+++ b/apps/docs/src/medusa-forms/ControlledInput.stories.tsx
@@ -1,5 +1,6 @@
 import { ControlledInput } from '@lambdacurry/medusa-forms/controlled/ControlledInput';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from '@storybook/test';
 import { FormProvider, useForm } from 'react-hook-form';
 
 const meta = {
@@ -14,10 +15,20 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+interface InputFormData {
+  username: string;
+  quantity: number | string;
+  optionalAmount: number | null | string;
+  startDate: Date | string;
+}
+
 const ControlledInputWithHookForm = () => {
-  const form = useForm({
+  const form = useForm<InputFormData>({
     defaultValues: {
       username: '',
+      quantity: '',
+      optionalAmount: '',
+      startDate: '',
     },
   });
 
@@ -30,6 +41,98 @@ const ControlledInputWithHookForm = () => {
   );
 };
 
+const NumberInputWithHookForm = () => {
+  const form = useForm<InputFormData>({
+    defaultValues: {
+      username: '',
+      quantity: '',
+      optionalAmount: '',
+      startDate: '',
+    },
+  });
+  const quantity = form.watch('quantity');
+
+  return (
+    <FormProvider {...form}>
+      <div className="w-[400px] space-y-4">
+        <ControlledInput<InputFormData>
+          name="quantity"
+          type="number"
+          label="Quantity"
+          rules={{ valueAsNumber: true }}
+        />
+        <pre className="rounded bg-gray-100 p-2 text-xs">
+          {JSON.stringify({ value: quantity, type: typeof quantity }, null, 2)}
+        </pre>
+      </div>
+    </FormProvider>
+  );
+};
+
+const NullableNumberInputWithHookForm = () => {
+  const form = useForm<InputFormData>({
+    defaultValues: {
+      username: '',
+      quantity: '',
+      optionalAmount: '',
+      startDate: '',
+    },
+  });
+  const optionalAmount = form.watch('optionalAmount');
+
+  return (
+    <FormProvider {...form}>
+      <div className="w-[400px] space-y-4">
+        <ControlledInput<InputFormData>
+          name="optionalAmount"
+          type="number"
+          label="Optional amount"
+          rules={{
+            setValueAs: (value) => (value === '' ? null : Number(value)),
+          }}
+        />
+        <pre className="rounded bg-gray-100 p-2 text-xs">
+          {JSON.stringify({ value: optionalAmount, type: typeof optionalAmount }, null, 2)}
+        </pre>
+      </div>
+    </FormProvider>
+  );
+};
+
+const DateInputWithHookForm = () => {
+  const form = useForm<InputFormData>({
+    defaultValues: {
+      username: '',
+      quantity: '',
+      optionalAmount: '',
+      startDate: '',
+    },
+  });
+  const startDate = form.watch('startDate');
+
+  return (
+    <FormProvider {...form}>
+      <div className="w-[400px] space-y-4">
+        <ControlledInput<InputFormData> name="startDate" type="date" label="Start date" rules={{ valueAsDate: true }} />
+        <pre className="rounded bg-gray-100 p-2 text-xs">
+          {JSON.stringify({ value: startDate, type: typeof startDate }, null, 2)}
+        </pre>
+      </div>
+    </FormProvider>
+  );
+};
+
+const getStateOutput = (canvas: ReturnType<typeof within>) => canvas.getByText((content) => content.includes('"type"'));
+const getInputByName = (canvasElement: HTMLElement, name: string) => {
+  const input = canvasElement.querySelector<HTMLInputElement>(`input[name="${name}"]`);
+
+  if (!input) {
+    throw new Error(`Input with name "${name}" was not found.`);
+  }
+
+  return input;
+};
+
 export const WithReactHookForm: Story = {
   args: {
     name: 'username',
@@ -37,4 +140,86 @@ export const WithReactHookForm: Story = {
     placeholder: 'Enter your username',
   },
   render: () => <ControlledInputWithHookForm />,
+  play: async ({ canvasElement }) => {
+    const input = getInputByName(canvasElement, 'username');
+
+    await userEvent.type(input, 'validuser');
+
+    expect(input).toHaveValue('validuser');
+  },
+};
+
+export const ValueAsNumber: Story = {
+  render: () => <NumberInputWithHookForm />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = getInputByName(canvasElement, 'quantity');
+    const state = getStateOutput(canvas);
+
+    await userEvent.type(input, '42');
+
+    await waitFor(() => {
+      expect(input).toHaveValue(42);
+      expect(state).toHaveTextContent('"value": 42');
+      expect(state).toHaveTextContent('"type": "number"');
+    });
+
+    await userEvent.clear(input);
+
+    await waitFor(() => {
+      expect(input).toHaveValue(null);
+      expect(state).toHaveTextContent('"value": null');
+      expect(state).toHaveTextContent('"type": "number"');
+    });
+  },
+};
+
+export const SetValueAs: Story = {
+  render: () => <NullableNumberInputWithHookForm />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = getInputByName(canvasElement, 'optionalAmount');
+    const state = getStateOutput(canvas);
+
+    await userEvent.type(input, '12');
+
+    await waitFor(() => {
+      expect(input).toHaveValue(12);
+      expect(state).toHaveTextContent('"value": 12');
+      expect(state).toHaveTextContent('"type": "number"');
+    });
+
+    await userEvent.clear(input);
+
+    await waitFor(() => {
+      expect(input).toHaveValue(null);
+      expect(state).toHaveTextContent('"value": null');
+      expect(state).toHaveTextContent('"type": "object"');
+    });
+  },
+};
+
+export const ValueAsDate: Story = {
+  render: () => <DateInputWithHookForm />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = getInputByName(canvasElement, 'startDate');
+    const state = getStateOutput(canvas);
+
+    await userEvent.type(input, '2026-06-24');
+
+    await waitFor(() => {
+      expect(input).toHaveValue('2026-06-24');
+      expect(state).toHaveTextContent('"value": "2026-06-24T');
+      expect(state).toHaveTextContent('"type": "object"');
+    });
+
+    await userEvent.clear(input);
+
+    await waitFor(() => {
+      expect(input).toHaveValue('');
+      expect(state).toHaveTextContent('"value": null');
+      expect(state).toHaveTextContent('"type": "object"');
+    });
+  },
 };

--- a/packages/medusa-forms/package.json
+++ b/packages/medusa-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambdacurry/medusa-forms",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "main": "./dist/cjs/index.cjs",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/medusa-forms/src/controlled/ControlledCurrencyInput.tsx
+++ b/packages/medusa-forms/src/controlled/ControlledCurrencyInput.tsx
@@ -1,38 +1,45 @@
 import type * as React from 'react';
-import {
-  Controller,
-  type ControllerProps,
-  type FieldValues,
-  type Path,
-  type RegisterOptions,
-  useFormContext,
-} from 'react-hook-form';
+import { Controller, type ControllerProps, type FieldValues, type Path, useFormContext } from 'react-hook-form';
 import { CurrencyInput, type CurrencyInputProps } from '../ui/CurrencyInput';
+import { type ControlledRules, serializeDisplayValue, splitTransformRules, transformValue } from './valueTransforms';
 
 export type ControlledCurrencyInputProps<T extends FieldValues> = CurrencyInputProps &
-  Omit<ControllerProps, 'render' | 'control'> & {
+  Omit<ControllerProps<T>, 'render' | 'control' | 'rules'> & {
     name: Path<T>;
+    rules?: ControlledRules<T>;
   };
 
 export const ControlledCurrencyInput = <T extends FieldValues>({
   name,
   rules,
+  onChange,
   ...props
 }: ControlledCurrencyInputProps<T>) => {
-  const { control } = useFormContext<T>();
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<T>();
+  const { controllerRules, hasTransform } = splitTransformRules(rules);
 
   return (
     <Controller<T>
       control={control}
       name={name}
-      rules={rules as Omit<RegisterOptions<T, Path<T>>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'>}
+      rules={controllerRules}
       render={({ field }) => {
         return (
           <CurrencyInput
             {...field}
             {...props}
+            formErrors={errors}
+            {...(hasTransform ? { value: serializeDisplayValue(field.value, rules) } : {})}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              field.onChange(e.target.value.replace(/[^0-9.-]+/g, ''));
+              if (onChange) {
+                onChange(e);
+              }
+
+              const value = e.target.value.replace(/[^0-9.-]+/g, '');
+              field.onChange(hasTransform ? transformValue(value, rules) : value);
             }}
           />
         );

--- a/packages/medusa-forms/src/controlled/ControlledInput.tsx
+++ b/packages/medusa-forms/src/controlled/ControlledInput.tsx
@@ -1,20 +1,16 @@
-import type { ComponentProps } from 'react';
-import {
-  Controller,
-  type ControllerProps,
-  type FieldValues,
-  type Path,
-  type RegisterOptions,
-  useFormContext,
-} from 'react-hook-form';
+import type { ChangeEvent, ComponentProps } from 'react';
+import { Controller, type ControllerProps, type FieldValues, type Path, useFormContext } from 'react-hook-form';
 import { Input, type InputProps } from '../ui/Input';
+import { type ControlledRules, serializeDisplayValue, splitTransformRules, transformValue } from './valueTransforms';
 
 export type ControlledInputProps<T extends FieldValues> = InputProps &
-  Omit<ControllerProps, 'render'> & {
+  Omit<ControllerProps<T>, 'render' | 'rules'> & {
     name: Path<T>;
-    rules?: Omit<RegisterOptions<T, Path<T>>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'>;
+    rules?: ControlledRules<T>;
   } & ComponentProps<typeof Input> &
-  Omit<ControllerProps<T>, 'render'>;
+  Omit<ControllerProps<T>, 'render' | 'rules'>;
+
+const getEventValue = (evt: ChangeEvent<HTMLInputElement>) => evt.target.value;
 
 export const ControlledInput = <T extends FieldValues>({
   name,
@@ -26,23 +22,25 @@ export const ControlledInput = <T extends FieldValues>({
     control,
     formState: { errors },
   } = useFormContext<T>();
+  const { controllerRules, hasTransform } = splitTransformRules(rules);
 
   return (
     <Controller
       control={control}
       name={name}
-      rules={rules as Omit<RegisterOptions<T, Path<T>>, 'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'>}
+      rules={controllerRules}
       render={({ field }) => (
         <Input
           {...field}
           {...props}
           labelClassName={props.labelClassName}
           formErrors={errors}
+          {...(hasTransform ? { value: serializeDisplayValue(field.value, rules) } : {})}
           onChange={(evt) => {
             if (onChange) {
               onChange(evt);
             }
-            field.onChange(evt);
+            field.onChange(hasTransform ? transformValue(getEventValue(evt), rules) : evt);
           }}
         />
       )}

--- a/packages/medusa-forms/src/controlled/valueTransforms.ts
+++ b/packages/medusa-forms/src/controlled/valueTransforms.ts
@@ -1,0 +1,57 @@
+import type { FieldValues, Path, RegisterOptions } from 'react-hook-form';
+
+export type ControlledRules<T extends FieldValues> = Omit<RegisterOptions<T, Path<T>>, 'disabled'>;
+type ControllerRules<T extends FieldValues> = Omit<ControlledRules<T>, 'valueAsNumber' | 'valueAsDate' | 'setValueAs'>;
+
+export const splitTransformRules = <T extends FieldValues>(
+  rules: ControlledRules<T> | undefined,
+): { controllerRules: ControllerRules<T>; hasTransform: boolean } => {
+  const { valueAsNumber, valueAsDate, setValueAs, ...controllerRules } = rules ?? {};
+
+  return {
+    controllerRules,
+    hasTransform: Boolean(valueAsNumber || valueAsDate || setValueAs),
+  };
+};
+
+export const transformValue = <T extends FieldValues>(value: string, rules: ControlledRules<T> | undefined) => {
+  if (rules?.valueAsNumber) {
+    return value === '' ? Number.NaN : +value;
+  }
+
+  if (rules?.valueAsDate) {
+    return new Date(value);
+  }
+
+  if (typeof rules?.setValueAs === 'function') {
+    return rules.setValueAs(value);
+  }
+
+  return value;
+};
+
+const isInvalidDate = (value: Date) => Number.isNaN(value.getTime());
+
+export const serializeDisplayValue = <T extends FieldValues>(value: unknown, rules: ControlledRules<T> | undefined) => {
+  if (value == null) {
+    return '';
+  }
+
+  if (rules?.valueAsNumber) {
+    return typeof value === 'number' && Number.isNaN(value) ? '' : String(value);
+  }
+
+  if (rules?.valueAsDate) {
+    if (!(value instanceof Date) || isInvalidDate(value)) {
+      return '';
+    }
+
+    return value.toISOString().slice(0, 10);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item));
+  }
+
+  return String(value);
+};


### PR DESCRIPTION
## Summary
- bump @lambdacurry/medusa-forms to 0.3.0
- allow ControlledInput and ControlledCurrencyInput rules to include RHF transform helpers
- apply valueAsNumber/valueAsDate/setValueAs before updating RHF state while preserving default behavior
- serialize transformed field state back into DOM-safe input values so NaN/Date/null values do not leak into rendered inputs
- keep currency inputs storing sanitized strings by default, with numeric state available via valueAsNumber or custom setValueAs
- pass formErrors through ControlledCurrencyInput and add executable Storybook coverage for transforms/error rendering
- run Storybook browser tests in CI

## Validation
- ./node_modules/.bin/biome check packages/medusa-forms/src/controlled/ControlledInput.tsx packages/medusa-forms/src/controlled/ControlledCurrencyInput.tsx packages/medusa-forms/src/controlled/valueTransforms.ts apps/docs/src/medusa-forms/ControlledInput.stories.tsx apps/docs/src/medusa-forms/ControlledCurrencyInput.stories.tsx
- ./node_modules/.bin/tsc --noEmit -p packages/medusa-forms/tsconfig.json --types vite/client
- node .yarn/releases/yarn-4.9.1.cjs workspace @lambdacurry/medusa-forms build
- node .yarn/releases/yarn-4.9.1.cjs workspace @lambdacurry/medusa-forms-docs build-storybook
- node .yarn/releases/yarn-4.9.1.cjs workspace @lambdacurry/medusa-forms-docs test (51 passed)

## Notes
- yarn workspace @lambdacurry/medusa-forms type-check currently fails because the shared tsconfig references missing @react-router/node types.
- yarn workspace @lambdacurry/medusa-forms lint resolved a Biome 2.x binary in the workspace script and rejected the repo's Biome 1.9 config; direct root Biome 1.9.4 on the touched files passes.